### PR TITLE
Pause jobs before it's reserved

### DIFF
--- a/lib/qless/worker/serial.rb
+++ b/lib/qless/worker/serial.rb
@@ -27,12 +27,6 @@ module Qless
             log(:debug, "Starting job #{job.klass_name} (#{job.jid} from #{job.queue_name})")
             perform(job)
             log(:debug, "Finished job #{job.klass_name} (#{job.jid} from #{job.queue_name})")
-
-            # So long as we're paused, we should wait
-            while paused
-              log(:debug, 'Paused...')
-              sleep interval
-            end
           end
         end
       end


### PR DESCRIPTION
qless checks for paused workers after running a job, so to actually pause the worker, we need to send a signal and send a job for it to actually pause again.

So I moved the pause check before worker reserves the job to run. This worked on my tests on staging.

/cc @jeromecornet @garymardell 