### PR TITLE
Loosen sinatra restrictions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       redis (>= 2.2, < 4.0.0.rc1)
       rusage (~> 0.2.0)
       sentry-raven (~> 0.4)
-      sinatra (~> 2.0.0)
+      sinatra (>= 1.3, < 2.1)
       statsd-ruby (~> 1.3)
       thin (~> 1.7)
       thor (~> 0.19.1)
@@ -163,4 +163,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.15.0
+   1.15.3

--- a/qless.gemspec
+++ b/qless.gemspec
@@ -39,7 +39,7 @@ language-specific extension will also remain up to date.
   s.add_dependency 'redis', ['>= 2.2', '< 4.0.0.rc1']
   s.add_dependency 'rusage', '~> 0.2.0'
   s.add_dependency 'sentry-raven', '~> 0.4'
-  s.add_dependency 'sinatra', '~> 2.0.0'
+  s.add_dependency 'sinatra', ['>= 1.3', '< 2.1']
   s.add_dependency 'statsd-ruby', '~> 1.3'
   s.add_dependency 'thin', '~> 1.7'
   s.add_dependency 'thor', '~> 0.19.1'


### PR DESCRIPTION
While updating Russbot to Rails 5, I'd like to avoid the diff noise generated by bumping `qless` along with `rails`, thus, I want to upgrade `qless` first and separately. This requires the same version of `qless` to support both sinatra on `rack ~> 1.0` as well as sinatra on `rack = 2.0`. I see no real reason why we would be to restrictive on the sinatra version as we've seen it work well with both versions.

cc @girasquid @sluggoman 