### PR TITLE
Prevent CSRF by blocking cross-origin AJAX requests.

### DIFF
--- a/lib/qless/server.rb
+++ b/lib/qless/server.rb
@@ -156,6 +156,10 @@ module Qless
       end
     end
 
+    before do
+      halt 422 unless request.get? || request.xhr?
+    end
+
     get '/?' do
       erb :overview, layout: true, locals: { title: 'Overview' }
     end
@@ -290,17 +294,9 @@ module Qless
       job = client.jobs[data['id']]
       if !job.nil?
         data.fetch('tags', false) ? job.track(*data['tags']) : job.track
-        if request.xhr?
-          json({ tracked: [job.jid] })
-        else
-          redirect to('/track')
-        end
+        json({ tracked: [job.jid] })
       else
-        if request.xhr?
-          json({ tracked: [] })
-        else
-          redirect to(request.referrer)
-        end
+        json({ tracked: [] })
       end
     end
 
@@ -464,11 +460,7 @@ module Qless
         job.cancel
       end
 
-      if request.xhr?
-        return json({ canceled: jobs.map { |job| job.jid } })
-      else
-        redirect to(request.referrer)
-      end
+      return json({ canceled: jobs.map { |job| job.jid } })
     end
 
     post '/cancelall/?' do


### PR DESCRIPTION
Currently qless lacks CSRF protection. Since all POST requests to qless are AJAX, cross-origin requests can be blocked simply by checking for the `X-Requested-With: XMLHttpRequest` header, which is only present in same-origin AJAX requests.

I chose this approach instead of the standard CSRF token approach because qless does not currently use sessions or cookies at all.