### PR TITLE
Fix cross-site scripting in notification messages.

### DIFF
--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -67,7 +67,7 @@
      * in a vein similar to that of Ruby's flash */
     var flash = function(message, t, duration) {
       var noty_id = noty({
-        text   : '<strong>' + message + '</strong>',
+        text   : $('<strong/>').text(message),
         layout : 'top',
         type   : t || 'error',
         theme  : 'noty_theme_twitter',


### PR DESCRIPTION
Flash messages often contain user input. Currently, they are inserted into a `<strong>` tag without escaping, resulting in XSS. I've fixed the issue by setting the text of the `<strong>` tag using jQuery's `text` function.

Also, I bumped jQuery up to the latest 1.x release to pick up security fixes. In particular, versions prior to 1.9 had an issue where HTML tags appearing in selectors could be interpreted as HTML instead of a selector, which could make this code vulnerable to XSS:

https://github.com/Shopify/qless/blob/b612ec931aecc9e2767a19e085d054944b5c14eb/lib/qless/server/views/job.erb#L4