### PR TITLE
Fix queue name XSS

### DIFF
--- a/lib/qless/server/views/layout.erb
+++ b/lib/qless/server/views/layout.erb
@@ -282,36 +282,46 @@
       }
     }
 
-    var pause = function(queue) {
+    var pause = function(button) {
+      var button = $(button);
+      var queue = button.attr('data-queue');
+
       _ajax({
         url: <%== u("/pause").to_json %>,
         data: {
           'queue': queue
         }, success: function(data) {
-          var button = $('#' + queue + '-pause');
-          button.attr('title', 'Unpause').attr(
-            'data-original-title', 'Unpause');
-          button.addClass('btn-success').removeClass('btn-warning');
-          button.children().addClass('icon-play').removeClass('icon-pause');
-          button.attr('onclick', 'unpause("' + queue + '")');
+          button.attr({
+            'title': 'Unpause',
+            'data-original-title': 'Unpause',
+            'onclick': 'unpause(this)',
+            'class': 'btn btn-success'
+          });
+
+          button.children().attr('class', 'icon-play');
         }, error: function() {
           flash('Couldn\'t pause queue ' + queue);
         }
       })
     }
 
-    var unpause = function(queue) {
+    var unpause = function(button) {
+      var button = $(button);
+      var queue = button.attr('data-queue');
+
       _ajax({
         url: <%== u("/unpause").to_json %>,
         data: {
           'queue': queue
         }, success: function(data) {
-          var button = $('#' + queue + '-pause');
-          button.attr('title', 'Pause').attr(
-            'data-original-title', 'Pause');
-          button.addClass('btn-warning').removeClass('btn-success');
-          button.children().addClass('icon-pause').removeClass('icon-play');
-          button.attr('onclick', 'pause("' + queue + '")');
+          button.attr({
+            'title': 'Pause',
+            'data-original-title': 'Pause',
+            'onclick': 'pause(this)',
+            'class': 'btn btn-warning'
+          });
+
+          button.children().attr('class', 'icon-pause');
         }, error: function() {
           flash('Couldn\'t unpause queue ' + queue);
         }

--- a/lib/qless/server/views/overview.erb
+++ b/lib/qless/server/views/overview.erb
@@ -28,14 +28,16 @@
             id="<%= queue['name'] %>-pause"
             title="Unpause"
             class="btn btn-success"
-            onclick="unpause(<%= queue['name'].to_json %>)"><i class="icon-play"></i>
+            data-queue="<%= queue['name'] %>"
+            onclick="unpause(this)"><i class="icon-play"></i>
           </button>
         <% else %>
           <button
             id="<%= queue['name'] %>-pause"
             title="Pause"
             class="btn btn-warning"
-            onclick="pause(<%= queue['name'].to_json %>)"><i class="icon-pause"></i>
+            data-queue="<%= queue['name'] %>"
+            onclick="pause(this)"><i class="icon-pause"></i>
           </button>
         <% end %>
         <a href="<%= u "/queues/#{CGI::escape(queue['name'])}" %>"><%= queue['name'] %></a>

--- a/lib/qless/server/views/queues.erb
+++ b/lib/qless/server/views/queues.erb
@@ -16,14 +16,16 @@
             id="<%= queue['name'] %>-pause"
             title="Unpause"
             class="btn btn-success"
-            onclick="unpause(<%= queue['name'].to_json %>)"><i class="icon-play"></i>
+            data-queue="<%= queue['name'] %>"
+            onclick="unpause(this)"><i class="icon-play"></i>
           </button>
         <% else %>
           <button
             id="<%= queue['name'] %>-pause"
             title="Pause"
             class="btn btn-warning"
-            onclick="pause(<%= queue['name'].to_json %>)"><i class="icon-pause"></i>
+            data-queue="<%= queue['name'] %>"
+            onclick="pause(this)"><i class="icon-pause"></i>
           </button>
         <% end %>
         <a href="<%= u "/queues/#{CGI::escape(queue['name'])}" %>"><%= queue['name'] %></a>


### PR DESCRIPTION
The queue name is interpolated into a jQuery selector and a JavaScript event handler. This fix removes the need to interpolate this value and cleans up the handlers a bit.