### PR TITLE
Manually patch qless lua scripts to work with Redis 6.2.7

### DIFF
--- a/lib/qless/lua/qless-lib.lua
+++ b/lib/qless/lua/qless-lib.lua
@@ -33,7 +33,7 @@ QlessRecurringJob.__index = QlessRecurringJob
 Qless.config = {}
 
 -- Extend a table. This comes up quite frequently
-function table.extend(self, other)
+local function extend_table(self, other)
   for i, v in ipairs(other) do
     table.insert(self, v)
   end
@@ -1522,7 +1522,7 @@ function QlessQueue:peek(now, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  extend_table(jids, self.work.peek(count - #jids))
 
   return jids
 end
@@ -1597,7 +1597,7 @@ function QlessQueue:pop(now, worker, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  extend_table(jids, self.work.peek(count - #jids))
 
   local state
   for index, jid in ipairs(jids) do

--- a/lib/qless/lua/qless.lua
+++ b/lib/qless/lua/qless.lua
@@ -24,7 +24,7 @@ QlessRecurringJob.__index = QlessRecurringJob
 
 Qless.config = {}
 
-function table.extend(self, other)
+local function extend_table(self, other)
   for i, v in ipairs(other) do
     table.insert(self, v)
   end
@@ -1118,7 +1118,7 @@ function QlessQueue:peek(now, count)
 
   self:check_scheduled(now, count - #jids)
 
-  table.extend(jids, self.work.peek(count - #jids))
+  extend_table(jids, self.work.peek(count - #jids))
 
   return jids
 end
@@ -1167,7 +1167,7 @@ function QlessQueue:pop(now, worker, count)
 
   self:check_scheduled(now, count - #jids)
 
-  table.extend(jids, self.work.peek(count - #jids))
+  extend_table(jids, self.work.peek(count - #jids))
 
   local state
   for index, jid in ipairs(jids) do


### PR DESCRIPTION
More context:
- [qless fix](https://github.com/ledgetech/lua-resty-qless/pull/14)
- [redis 6.2.7 breaking change](https://github.com/redis/redis/pull/10651)

I did not regenerate the files from qless-core using the `make` instructions from the README.md because the commit we have been using [^1] dates back to Aug 2017, and the same fix has not been applied to seomoz/qless-core yet. See [^2]

[^1]: https://github.com/seomoz/qless-core/commit/36199bfcabc3216b754bb75fa9912a1d48f0b1b4

[^2]: https://github.com/seomoz/qless-core/pull/90